### PR TITLE
Add project description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,7 @@
 title: Restify
 email: wblankenship@netflix.com
 description:
-  Jekyll Template for Project Websites
-  providing documentation and blog post pages.
+  The future of Node.js REST development
 
 baseurl: "" # the subpath of your site, e.g. /blog/
 url: https://restify.github.io # the base hostname & protocol for your site


### PR DESCRIPTION
When doing a search for Restify, I noticed that this site lacked a unique description `meta` tag. 

Here's how the site currently appears in search results:

![screen shot 2017-08-03 at 1 22 09 pm](https://user-images.githubusercontent.com/212533/28934423-db6815e2-784e-11e7-9a58-6daba0fdb57b.png)

This adds a description to the config based on the description located on the site itself. 

