### PR TITLE
fix(config): replace default description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,8 @@
 title: Restify
 email: wblankenship@netflix.com
 description:
-  Jekyll Template for Project Websites
-  providing documentation and blog post pages.
+  A Node.js web service framework optimized for building semantically
+  correct RESTful web services ready for production use at scale.
 
 baseurl: "" # the subpath of your site, e.g. /blog/
 url: https://restify.github.io # the base hostname & protocol for your site


### PR DESCRIPTION
Site template contains default text that shows up as project description in search results.

Related issues:

- https://github.com/restify/node-restify/issues/1541